### PR TITLE
Revert the API changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ async initializeFeatureHub() {
     if (!initialized) {
       if (readyness === Readyness.Ready) {
         initialized = true;
-        const value = fhClient.feature('FEATURE_KEY').str;
+        const value = fhClient.getString('FEATURE_KEY');
         console.log('Value is ', value);
       }
     }
@@ -204,7 +204,7 @@ async initializeFeatureHub() {
   // react to incoming feature changes in real-time. With NodeJS apps it is recommended to 
   // use it as a global variable to avoid a memory leak
   fhClient.feature('FEATURE_KEY').addListener(fs => {
-    console.log('Value is ', fs.str);
+    console.log('Value is ', fs.getString());
   });
 }
  
@@ -218,22 +218,15 @@ this.initializeFeatureHub();
 #### Supported feature state requests
 
 * Get a raw feature value through the following methods:
-  - `getFlag('FEATURE_KEY') | getBoolean('FEATURE_KEY')` returns a boolean feature (by key) or _undefined_ if the feature does not exist. Alternatively use `feature('FEATURE_KEY').flag`
+  - `getFlag('FEATURE_KEY') | getBoolean('FEATURE_KEY')` returns a boolean feature (by key) or _undefined_ if the feature does not exist. 
   
-  - `getNumber('FEATURE_KEY')` | `getString('FEATURE_KEY')` | `getJson('FEATURE_KEY')` returns the value or _undefined_ if the feature is empty or does not exist. Alternatively use `feature('FEATURE_KEY').num`, `feature('FEATURE_KEY').str`, `feature('FEATURE_KEY').rawJson`
+  - `getNumber('FEATURE_KEY')` | `getString('FEATURE_KEY')` | `getJson('FEATURE_KEY')` returns the value or _undefined_ if the feature is empty or does not exist. 
 * Use convenience functions:
   - `isEnabled('FEATURE_KEY')` - always returns a _true_ or _false_, _true_
-    only if the feature is a boolean and is _true_, otherwise _false_. Alternatively use `feature('FEATURE_KEY').enabled`
+    only if the feature is a boolean and is _true_, otherwise _false_.
   - `isSet('FEATURE_KEY')` - in case a feature value is not set (_null_) (this can only happen for strings, numbers and json types), this check returns _false_.
     If a feature doesn't exist - returns _false_. Otherwise, returns _true_.
-
-  - `feature('FEATURE_KEY').exists` - returns _true_ if the flag is represented by a flag from FeatureHub. If a flag is requested that has not been created
-    yet, this will be `false`.
-  - `feature('FEATURE_KEY').locked` - returns _true_ if feature is locked, otherwise _false_
-  - `feature('FEATURE_KEY').version` - returns feature update version number (every change on the feature causes its version to update).
-  - `feature('FEATURE_KEY').type` - returns type of feature (boolean, string, number or json)
-  - `feature('FEATURE_KEY').addListener` - see _Feature updates listener_ below.
-  
+    
 
 ## Rollout Strategies and Client Context
 
@@ -247,7 +240,7 @@ For more details on rollout strategies, targeting rules and feature experiments 
 const fhClient = await fhConfig.newContext().userKey('user.email@host.com').country(StrategyAttributeCountryName.NewZealand)
  	.build();
 
-    if (fhClient.feature('FEATURE_KEY').enabled) {
+    if (fhClient.isEnabled('FEATURE_KEY')) {
         //do something
     };
 ```
@@ -426,7 +419,7 @@ fhConfig.addReadynessListener(async (readyness: Readyness): void => {
     startServer();
     fhInitialized = true;
     const fhClient = await fhConfig.newContext().build();
-    if (fhClient.feature('FEATURE_KEY').flag) {
+    if (fhClient.getFlag('FEATURE_KEY')) {
       // do something
     }
   } else if (readyness === Readyness.Failed && failCounter > 5) {
@@ -454,7 +447,7 @@ fhConfig.addReadynessListener(async (ready) => {
       console.log("Features are available, starting server...");
       initialized = true;
       const fhClient = await fhConfig.newContext().build();
-      if(fhClient.feature('FEATURE_KEY').flag) { 
+      if(fhClient.getFlag('FEATURE_KEY')) { 
           // do something
       }
       else {
@@ -747,7 +740,7 @@ this means when you are processing your request it will attempt to use the bagga
 fall back onto the rules in your featurehub repository. Your code still looks the same inside your nodejs code. 
 
 ```typescript
-if (req.ctx.feature('FEATURE_TITLE_TO_UPPERCASE').flag) {
+if (req.ctx.feature('FEATURE_TITLE_TO_UPPERCASE').getBoolean()) {
 }
 ```
                       

--- a/featurehub-javascript-client-sdk/CHANGELOG.md
+++ b/featurehub-javascript-client-sdk/CHANGELOG.md
@@ -1,8 +1,6 @@
 #### 1.0.12
 - Reverted the change from 1.0.11 as that forced a new version (4.3+) of Typescript for Typescript users. This version
   remains compatible with Typescript 3.9.x
-#### 1.0.11
-- Provided additional getters to get feature values and properties [GitHub PR](https://github.com/featurehub-io/featurehub/pull/656/)
 #### 1.0.10
 - Fix a bug related to Catch & Release mode [GitHub issue](https://github.com/featurehub-io/featurehub/issues/648)
 #### 1.0.9

--- a/featurehub-javascript-client-sdk/CHANGELOG.md
+++ b/featurehub-javascript-client-sdk/CHANGELOG.md
@@ -1,3 +1,6 @@
+#### 1.0.12
+- Reverted the change from 1.0.11 as that forced a new version (4.3+) of Typescript for Typescript users. This version
+  remains compatible with Typescript 3.9.x
 #### 1.0.11
 - Provided additional getters to get feature values and properties [GitHub PR](https://github.com/featurehub-io/featurehub/pull/656/)
 #### 1.0.10

--- a/featurehub-javascript-client-sdk/app/client_feature_repository.ts
+++ b/featurehub-javascript-client-sdk/app/client_feature_repository.ts
@@ -139,20 +139,20 @@ export class ClientFeatureRepository implements InternalFeatureRepository {
     const vals = new Map<string, string | undefined>();
 
     this.features.forEach((value, key) => {
-      if (value.exists) { // only include valid features
+      if (value.getKey()) { // only include value features
         let val: any;
         switch (value.getType()) {// we need to pick up any overrides
           case FeatureValueType.Boolean:
-            val = value.flag ? 'true' : 'false';
+            val = value.getBoolean() ? 'true' : 'false';
             break;
           case FeatureValueType.String:
-            val = value.str;
+            val = value.getString();
             break;
           case FeatureValueType.Number:
-            val = value.num;
+            val = value.getNumber();
             break;
           case FeatureValueType.Json:
-            val = value.rawJson;
+            val = value.getRawJson();
             break;
           default:
             val = undefined;
@@ -307,10 +307,12 @@ export class ClientFeatureRepository implements InternalFeatureRepository {
   }
 
   private deleteFeature(featureState: FeatureState) {
+    featureState.value = undefined;
+
     const holder = this.features.get(featureState.key);
 
     if (holder) {
-      holder.setFeatureState(undefined);
+      holder.setFeatureState(featureState);
     }
   }
 }

--- a/featurehub-javascript-client-sdk/app/feature_state.ts
+++ b/featurehub-javascript-client-sdk/app/feature_state.ts
@@ -11,51 +11,21 @@ export interface FeatureListener {
 export interface FeatureStateHolder {
   getKey(): string | undefined;
 
-  get key(): string | undefined;
-
   getString(): string | undefined;
-
-  get str(): string | undefined;
 
   getBoolean(): boolean | undefined;
 
   getFlag(): boolean | undefined;
 
-  get flag(): boolean | undefined;
-
-  /**
-   * A number (or undefined if no value exists for it). Only for a number feature.
-   */
   getNumber(): number | undefined;
 
-  get num(): number | undefined;
-
-  /**
-   * getRawJson(): The raw json value of the data
-   */
   getRawJson(): string | undefined;
 
-  get rawJson(): string | undefined;
-
-  /**
-   * isSet: does this feature value a value
-   */
   isSet(): boolean;
-
-  /**
-   * exists: does this feature actually exist, have we ever received state for it. If it was asked
-   * for before it we received state for it and it still has no state, or it was deleted, this will be
-   * false, otherwise it will be true.
-   */
-  get exists(): boolean;
 
   isLocked(): boolean | undefined;
 
-  get locked(): boolean | undefined;
-
   isEnabled(): boolean;
-
-  get enabled(): boolean;
 
   addListener(listener: FeatureListener): void;
 
@@ -66,11 +36,7 @@ export interface FeatureStateHolder {
 
   getVersion(): number | undefined;
 
-  get version(): number | undefined;
-
   getType(): FeatureValueType | undefined;
-
-  get type(): FeatureValueType | undefined;
 
   withContext(param: ClientContext): FeatureStateHolder;
 }

--- a/featurehub-javascript-client-sdk/app/feature_state_holders.ts
+++ b/featurehub-javascript-client-sdk/app/feature_state_holders.ts
@@ -4,7 +4,7 @@ import { ClientContext } from './client_context';
 import { InternalFeatureRepository } from './internal_feature_repository';
 
 export class FeatureStateBaseHolder implements FeatureStateHolder {
-  protected internalFeatureState: FeatureState | undefined;
+  protected internalFeatureState: FeatureState;
   protected _key: string;
   protected listeners: Array<FeatureListener> = [];
   protected _repo: InternalFeatureRepository;
@@ -18,46 +18,6 @@ export class FeatureStateBaseHolder implements FeatureStateHolder {
 
     this._repo = repository;
     this._key = key;
-  }
-
-  get key(): string {
-    return this.getKey();
-  }
-
-  get str(): string {
-    return this.getString();
-  }
-
-  get flag(): boolean {
-    return this.getFlag();
-  }
-
-  get num(): number {
-    return this.getNumber();
-  }
-
-  get rawJson(): string {
-    return this.getRawJson();
-  }
-
-  get exists(): boolean {
-    return this.internalFeatureState !== undefined;
-  }
-
-  get locked(): boolean {
-    return this.isLocked();
-  }
-
-  get enabled(): boolean {
-    return this.isEnabled();
-  }
-
-  get version(): number {
-    return this.getVersion();
-  }
-
-  get type(): FeatureValueType {
-    return this.getType();
   }
 
   public withContext(param: ClientContext): FeatureStateHolder {
@@ -113,7 +73,7 @@ export class FeatureStateBaseHolder implements FeatureStateHolder {
 
   /// returns true if the value changed, _only_ the repository should call this
   /// as it is dereferenced via the parentHolder
-  setFeatureState(fs: FeatureState | undefined): boolean {
+  setFeatureState(fs: FeatureState): boolean {
     const existingValue = this._getValue();
     const existingLocked = this.featureState()?.l;
 
@@ -171,7 +131,7 @@ export class FeatureStateBaseHolder implements FeatureStateHolder {
     return bh;
   }
 
-  private featureState(): FeatureState | undefined {
+  private featureState(): FeatureState {
     if (this.internalFeatureState !== undefined) {
       return this.internalFeatureState;
     }

--- a/featurehub-javascript-client-sdk/app/middleware.ts
+++ b/featurehub-javascript-client-sdk/app/middleware.ts
@@ -101,46 +101,6 @@ class BaggageHolder implements FeatureStateHolder {
   triggerListeners(feature: FeatureStateHolder): void {
     this.existing.triggerListeners(feature);
   }
-
-  get enabled(): boolean {
-    return this.isEnabled();
-  }
-
-  get exists(): boolean {
-    return this.existing.exists;
-  }
-
-  get flag(): boolean | undefined {
-    return this.getBoolean();
-  }
-
-  get key(): string | undefined {
-    return this.getKey();
-  }
-
-  get locked(): boolean | undefined {
-    return this.isLocked();
-  }
-
-  get num(): number | undefined {
-    return this.getNumber();
-  }
-
-  get rawJson(): string | undefined {
-    return this.getRawJson();
-  }
-
-  get str(): string | undefined {
-    return this.getString();
-  }
-
-  get type(): FeatureValueType | undefined {
-    return this.getType();
-  }
-
-  get version(): number | undefined {
-    return this.getVersion();
-  }
 }
 
 class BaggageRepository implements InternalFeatureRepository {

--- a/featurehub-javascript-client-sdk/package-lock.json
+++ b/featurehub-javascript-client-sdk/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "featurehub-javascript-client-sdk",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2742,9 +2742,9 @@
       }
     },
     "typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
       "dev": true
     },
     "uri-js": {

--- a/featurehub-javascript-client-sdk/package.json
+++ b/featurehub-javascript-client-sdk/package.json
@@ -1,13 +1,16 @@
 {
   "name": "featurehub-javascript-client-sdk",
-  "version": "1.0.11",
-  "description": "FeatureHub client/browser SDK",
+  "version": "1.0.12",
+  "description": "Core package of API that exposes FeatureHub feature flags, values and configuration to client applications written in Typescript or Javascript.",
   "author": "info@featurehub.io",
   "sideEffects": false,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "module": "lib/index.js",
-  "repository": "github:featurehub-io/featurehub-javascript-sdk",
+  "repository": {
+    "type": "git",
+    "url": ""
+  },
   "files": [
     "dist/**/*",
     "lib/**/*"
@@ -40,7 +43,7 @@
     "tsc": "node ./node_modules/typescript/bin/tsc -p",
     "link": "npm link",
     "compile": "npm run build && npm link",
-    "release": "cp ../README.md . && npm run build && npm publish",
+    "release": "npm run build && npm publish",
     "prepublishOnly": "npm run build",
     "lint": "./node_modules/.bin/eslint . --ext .js,.jsx,.ts,.tsx --fix"
   },
@@ -58,7 +61,7 @@
     "@typescript-eslint/eslint-plugin": "^4.11.0",
     "@typescript-eslint/parser": "^4.11.0",
     "@typescript-eslint/typescript-estree": "^4.11.0",
-    "typescript": "4.5.4"
+    "typescript": "3.9.7"
   },
   "dependencies": {
     "@types/murmurhash": "^2.0.0",

--- a/featurehub-javascript-client-sdk/package.json
+++ b/featurehub-javascript-client-sdk/package.json
@@ -1,16 +1,13 @@
 {
 	"name": "featurehub-javascript-client-sdk",
-	"version": "1.0.12",
-	"description": "Core package of API that exposes FeatureHub feature flags, values and configuration to client applications written in Typescript or Javascript.",
+	"version": "1.0.11",
+	"description": "FeatureHub client/browser SDK",
 	"author": "info@featurehub.io",
 	"sideEffects": false,
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
 	"module": "lib/index.js",
-	"repository": {
-		"type": "git",
-		"url": ""
-	},
+	"repository": "github:featurehub-io/featurehub-javascript-sdk",
 	"files": [
 		"dist/**/*",
 		"lib/**/*"
@@ -43,7 +40,7 @@
 		"tsc": "node ./node_modules/typescript/bin/tsc -p",
 		"link": "npm link",
 		"compile": "npm run build && npm link",
-		"release": "npm run build && npm publish",
+		"release": "cp ../README.md . && npm run build && npm publish",
 		"prepublishOnly": "npm run build",
 		"lint": "./node_modules/.bin/eslint . --ext .js,.jsx,.ts,.tsx --fix"
 	},

--- a/featurehub-javascript-client-sdk/package.json
+++ b/featurehub-javascript-client-sdk/package.json
@@ -1,72 +1,72 @@
 {
-	"name": "featurehub-javascript-client-sdk",
-	"version": "1.0.11",
-	"description": "FeatureHub client/browser SDK",
-	"author": "info@featurehub.io",
-	"sideEffects": false,
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
-	"module": "lib/index.js",
-	"repository": "github:featurehub-io/featurehub-javascript-sdk",
-	"files": [
-		"dist/**/*",
-		"lib/**/*"
-	],
-	"homepage": "https://featurehub.io",
-	"keywords": [
-		"feature-flag-api",
-		"feature-flag-sdk",
-		"feature-experimentation",
-		"feature-flag",
-		"flag",
-		"toggle",
-		"feature-toggle",
-		"feature-toggle-api",
-		"remote-configuration",
-		"gradual-rollout",
-		"ab-testing",
-		"feature-flag-react",
-		"featurehub"
-	],
-	"license": "MIT",
-	"scripts": {
-		"build": "npm run clean && npm run tsc tsconfig.json && npm run tsc tsconfig-es.json",
-		"clean": "rm -rf dist lib && rm -rf app/*.js app/*.d.ts app/*.map",
-		"build:watch": "npm run build -- -- -w",
-		"mocha": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' node ./node_modules/mocha/bin/mocha --config mocharc.yml",
-		"test": "npm run clean && npm run tsc tsconfig.json && npm run mocha",
-		"coverage": "nyc npm run test",
-		"test:watch": "npm run mocha --opts mocha.opts --watch",
-		"tsc": "node ./node_modules/typescript/bin/tsc -p",
-		"link": "npm link",
-		"compile": "npm run build && npm link",
-		"release": "cp ../README.md . && npm run build && npm publish",
-		"prepublishOnly": "npm run build",
-		"lint": "./node_modules/.bin/eslint . --ext .js,.jsx,.ts,.tsx --fix"
-	},
-	"devDependencies": {
-		"@fluffy-spoon/substitute": "^1.208.0",
-		"@types/chai": "^4.2.18",
-		"@types/mocha": "^9.0.0",
-		"@types/node": "^12.20.12",
-		"chai": "^4.2.0",
-		"mocha": "^9.1.4",
-		"nyc": "^15.1.0",
-		"ts-node": "8.10.2",
-		"eslint": "^7.16.0",
-		"eslint-plugin-filenames-simple": "^0.6.0",
-		"@typescript-eslint/eslint-plugin": "^4.11.0",
-		"@typescript-eslint/parser": "^4.11.0",
-		"@typescript-eslint/typescript-estree": "^4.11.0",
-		"typescript": "3.9.7"
-	},
-	"dependencies": {
-		"@types/murmurhash": "^2.0.0",
-		"murmurhash": "^2.0.0",
-		"netmask": "^2.0.2",
-		"semver-compare": "^1.0.0"
-	},
-	"engines": {
-		"node": ">=12.12.0"
-	}
+  "name": "featurehub-javascript-client-sdk",
+  "version": "1.0.12",
+  "description": "FeatureHub client/browser SDK",
+  "author": "info@featurehub.io",
+  "sideEffects": false,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "module": "lib/index.js",
+  "repository": "github:featurehub-io/featurehub-javascript-sdk",
+  "files": [
+    "dist/**/*",
+    "lib/**/*"
+  ],
+  "homepage": "https://featurehub.io",
+  "keywords": [
+    "feature-flag-api",
+    "feature-flag-sdk",
+    "feature-experimentation",
+    "feature-flag",
+    "flag",
+    "toggle",
+    "feature-toggle",
+    "feature-toggle-api",
+    "remote-configuration",
+    "gradual-rollout",
+    "ab-testing",
+    "feature-flag-react",
+    "featurehub"
+  ],
+  "license": "MIT",
+  "scripts": {
+    "build": "npm run clean && npm run tsc tsconfig.json && npm run tsc tsconfig-es.json",
+    "clean": "rm -rf dist lib && rm -rf app/*.js app/*.d.ts app/*.map",
+    "build:watch": "npm run build -- -- -w",
+    "mocha": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' node ./node_modules/mocha/bin/mocha --config mocharc.yml",
+    "test": "npm run clean && npm run tsc tsconfig.json && npm run mocha",
+    "coverage": "nyc npm run test",
+    "test:watch": "npm run mocha --opts mocha.opts --watch",
+    "tsc": "node ./node_modules/typescript/bin/tsc -p",
+    "link": "npm link",
+    "compile": "npm run build && npm link",
+    "release": "cp ../README.md . && npm run build && npm publish",
+    "prepublishOnly": "npm run build",
+    "lint": "./node_modules/.bin/eslint . --ext .js,.jsx,.ts,.tsx --fix"
+  },
+  "devDependencies": {
+    "@fluffy-spoon/substitute": "^1.208.0",
+    "@types/chai": "^4.2.18",
+    "@types/mocha": "^9.0.0",
+    "@types/node": "^12.20.12",
+    "chai": "^4.2.0",
+    "mocha": "^9.1.4",
+    "nyc": "^15.1.0",
+    "ts-node": "8.10.2",
+    "eslint": "^7.16.0",
+    "eslint-plugin-filenames-simple": "^0.6.0",
+    "@typescript-eslint/eslint-plugin": "^4.11.0",
+    "@typescript-eslint/parser": "^4.11.0",
+    "@typescript-eslint/typescript-estree": "^4.11.0",
+    "typescript": "3.9.7"
+  },
+  "dependencies": {
+    "@types/murmurhash": "^2.0.0",
+    "murmurhash": "^2.0.0",
+    "netmask": "^2.0.2",
+    "semver-compare": "^1.0.0"
+  },
+  "engines": {
+    "node": ">=12.12.0"
+  }
 }

--- a/featurehub-javascript-client-sdk/package.json
+++ b/featurehub-javascript-client-sdk/package.json
@@ -1,75 +1,75 @@
 {
-  "name": "featurehub-javascript-client-sdk",
-  "version": "1.0.12",
-  "description": "Core package of API that exposes FeatureHub feature flags, values and configuration to client applications written in Typescript or Javascript.",
-  "author": "info@featurehub.io",
-  "sideEffects": false,
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "module": "lib/index.js",
-  "repository": {
-    "type": "git",
-    "url": ""
-  },
-  "files": [
-    "dist/**/*",
-    "lib/**/*"
-  ],
-  "homepage": "https://featurehub.io",
-  "keywords": [
-    "feature-flag-api",
-    "feature-flag-sdk",
-    "feature-experimentation",
-    "feature-flag",
-    "flag",
-    "toggle",
-    "feature-toggle",
-    "feature-toggle-api",
-    "remote-configuration",
-    "gradual-rollout",
-    "ab-testing",
-    "feature-flag-react",
-    "featurehub"
-  ],
-  "license": "MIT",
-  "scripts": {
-    "build": "npm run clean && npm run tsc tsconfig.json && npm run tsc tsconfig-es.json",
-    "clean": "rm -rf dist lib && rm -rf app/*.js app/*.d.ts app/*.map",
-    "build:watch": "npm run build -- -- -w",
-    "mocha": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' node ./node_modules/mocha/bin/mocha --config mocharc.yml",
-    "test": "npm run clean && npm run tsc tsconfig.json && npm run mocha",
-    "coverage": "nyc npm run test",
-    "test:watch": "npm run mocha --opts mocha.opts --watch",
-    "tsc": "node ./node_modules/typescript/bin/tsc -p",
-    "link": "npm link",
-    "compile": "npm run build && npm link",
-    "release": "npm run build && npm publish",
-    "prepublishOnly": "npm run build",
-    "lint": "./node_modules/.bin/eslint . --ext .js,.jsx,.ts,.tsx --fix"
-  },
-  "devDependencies": {
-    "@fluffy-spoon/substitute": "^1.208.0",
-    "@types/chai": "^4.2.18",
-    "@types/mocha": "^9.0.0",
-    "@types/node": "^12.20.12",
-    "chai": "^4.2.0",
-    "mocha": "^9.1.4",
-    "nyc": "^15.1.0",
-    "ts-node": "8.10.2",
-    "eslint": "^7.16.0",
-    "eslint-plugin-filenames-simple": "^0.6.0",
-    "@typescript-eslint/eslint-plugin": "^4.11.0",
-    "@typescript-eslint/parser": "^4.11.0",
-    "@typescript-eslint/typescript-estree": "^4.11.0",
-    "typescript": "3.9.7"
-  },
-  "dependencies": {
-    "@types/murmurhash": "^2.0.0",
-    "murmurhash": "^2.0.0",
-    "netmask": "^2.0.2",
-    "semver-compare": "^1.0.0"
-  },
-  "engines": {
-    "node": ">=12.12.0"
-  }
+	"name": "featurehub-javascript-client-sdk",
+	"version": "1.0.12",
+	"description": "Core package of API that exposes FeatureHub feature flags, values and configuration to client applications written in Typescript or Javascript.",
+	"author": "info@featurehub.io",
+	"sideEffects": false,
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"module": "lib/index.js",
+	"repository": {
+		"type": "git",
+		"url": ""
+	},
+	"files": [
+		"dist/**/*",
+		"lib/**/*"
+	],
+	"homepage": "https://featurehub.io",
+	"keywords": [
+		"feature-flag-api",
+		"feature-flag-sdk",
+		"feature-experimentation",
+		"feature-flag",
+		"flag",
+		"toggle",
+		"feature-toggle",
+		"feature-toggle-api",
+		"remote-configuration",
+		"gradual-rollout",
+		"ab-testing",
+		"feature-flag-react",
+		"featurehub"
+	],
+	"license": "MIT",
+	"scripts": {
+		"build": "npm run clean && npm run tsc tsconfig.json && npm run tsc tsconfig-es.json",
+		"clean": "rm -rf dist lib && rm -rf app/*.js app/*.d.ts app/*.map",
+		"build:watch": "npm run build -- -- -w",
+		"mocha": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' node ./node_modules/mocha/bin/mocha --config mocharc.yml",
+		"test": "npm run clean && npm run tsc tsconfig.json && npm run mocha",
+		"coverage": "nyc npm run test",
+		"test:watch": "npm run mocha --opts mocha.opts --watch",
+		"tsc": "node ./node_modules/typescript/bin/tsc -p",
+		"link": "npm link",
+		"compile": "npm run build && npm link",
+		"release": "npm run build && npm publish",
+		"prepublishOnly": "npm run build",
+		"lint": "./node_modules/.bin/eslint . --ext .js,.jsx,.ts,.tsx --fix"
+	},
+	"devDependencies": {
+		"@fluffy-spoon/substitute": "^1.208.0",
+		"@types/chai": "^4.2.18",
+		"@types/mocha": "^9.0.0",
+		"@types/node": "^12.20.12",
+		"chai": "^4.2.0",
+		"mocha": "^9.1.4",
+		"nyc": "^15.1.0",
+		"ts-node": "8.10.2",
+		"eslint": "^7.16.0",
+		"eslint-plugin-filenames-simple": "^0.6.0",
+		"@typescript-eslint/eslint-plugin": "^4.11.0",
+		"@typescript-eslint/parser": "^4.11.0",
+		"@typescript-eslint/typescript-estree": "^4.11.0",
+		"typescript": "3.9.7"
+	},
+	"dependencies": {
+		"@types/murmurhash": "^2.0.0",
+		"murmurhash": "^2.0.0",
+		"netmask": "^2.0.2",
+		"semver-compare": "^1.0.0"
+	},
+	"engines": {
+		"node": ">=12.12.0"
+	}
 }

--- a/featurehub-javascript-client-sdk/test/middleware_spec.ts
+++ b/featurehub-javascript-client-sdk/test/middleware_spec.ts
@@ -46,9 +46,7 @@ describe('middleware decodes and provides face to repository', () => {
     expect(nextCalled).to.be.true;
     const repo: InternalFeatureRepository = req.featureHub;
     expect(repo.feature('FEATURE_STRING').getString()).to.eq('blah*&=blah');
-    expect(repo.feature('FEATURE_STRING').str).to.eq('blah*&=blah');
     expect(repo.feature('FEATURE_BOOLEAN').getBoolean()).to.eq(true);
-    expect(repo.feature('FEATURE_BOOLEAN').flag).to.eq(true);
   });
 
   it('features that are locked cannot be overridden', () => {

--- a/featurehub-javascript-client-sdk/test/repository_delete_feature_spec.ts
+++ b/featurehub-javascript-client-sdk/test/repository_delete_feature_spec.ts
@@ -19,19 +19,17 @@ describe('if a feature is deleted it becomes undefined', () => {
     ];
 
     repo.notify(SSEResultState.Features, features);
-    expect(repo.feature('banana').flag).to.eq(true);
+    expect(repo.getFeatureState('banana').getBoolean()).to.eq(true);
     expect(repo.getFlag('banana')).to.eq(true);
-    expect(repo.feature('banana').exists).to.be.true;
     repo.notify(SSEResultState.DeleteFeature, features[0]);
     // tslint:disable-next-line:no-unused-expression
-    expect(repo.feature('banana').exists).to.be.false;
-    expect(repo.feature('banana').flag).to.undefined;
+    expect(repo.getFeatureState('banana').getBoolean()).to.undefined;
     // tslint:disable-next-line:no-unused-expression
     expect(repo.getFlag('banana')).to.undefined;
     // tslint:disable-next-line:no-unused-expression
     expect(repo.isSet('banana')).to.be.false;
     // tslint:disable-next-line:no-unused-expression
-    expect(repo.feature('banana').isSet()).to.be.false;
+    expect(repo.getFeatureState('banana').isSet()).to.be.false;
   });
 
   it('should ignore deleting a feature that doesnt exist', () => {

--- a/featurehub-javascript-client-sdk/test/repository_events_spec.ts
+++ b/featurehub-javascript-client-sdk/test/repository_events_spec.ts
@@ -235,9 +235,7 @@ describe('Feature repository reacts to incoming event lists as expected', () => 
     expect(triggerPear).to.eq(1);
     expect(triggerPeach).to.eq(1);
     expect(repo.getFeatureState('banana').getString()).to.eq('7.2');
-    expect(repo.feature('banana').str).to.eq('7.2');
     expect(repo.getFeatureState('pear').getString()).to.eq('15');
-    expect(repo.feature('pear').str).to.eq('15');
     expect(repo.getFeatureState('peach').getString()).to.eq('56534.23');
 
     const features2 = [

--- a/featurehub-javascript-client-sdk/test/repository_single_feature_spec.ts
+++ b/featurehub-javascript-client-sdk/test/repository_single_feature_spec.ts
@@ -21,29 +21,23 @@ describe('repository reacts to single feature changes as expected', () => {
     repo.notify(SSEResultState.Feature, { id: '1', key: 'pear', version: 1, type: FeatureValueType.String, value: 'now-set' });
 
     expect(repo.feature('pear').getVersion()).to.eq(1);
-    expect(repo.feature('pear').version).to.eq(1);
     expect(repo.feature('pear').getString()).to.eq('now-set');
-    expect(repo.feature('pear').str).to.eq('now-set');
   });
 
   it('should specify undefined for unknown feature values', () => {
     // tslint:disable-next-line:no-unused-expression
     expect(repo.getFeatureState('bool').getBoolean()).to.be.undefined;
-    expect(repo.getFeatureState('bool').flag).to.be.undefined;
     // tslint:disable-next-line:no-unused-expression
     expect(repo.getFeatureState('num').getNumber()).to.be.undefined;
-    expect(repo.getFeatureState('num').num).to.be.undefined;
     // tslint:disable-next-line:no-unused-expression
     expect(repo.getFeatureState('str').getString()).to.be.undefined;
-    expect(repo.getFeatureState('str').str).to.be.undefined;
     // tslint:disable-next-line:no-unused-expression
     expect(repo.getFeatureState('str').getRawJson()).to.be.undefined;
-    expect(repo.getFeatureState('str').rawJson).to.be.undefined;
 
     const ctx = Substitute.for<ClientContext>();
     const feat = repo.getFeatureState('bool').withContext(ctx);
     // tslint:disable-next-line:no-unused-expression
-    expect(feat.flag).to.be.undefined;
+    expect(feat.getBoolean()).to.be.undefined;
   });
 
   it('should be able to deal with pure json data', () => {
@@ -135,6 +129,5 @@ describe('repository reacts to single feature changes as expected', () => {
       type: FeatureValueType.Number, value: 12.9 })));
     // expect(triggerApricot).to.eq(2);
     expect(repo.feature('apricot').getNumber()).to.eq(12.9);
-    expect(repo.feature('apricot').num).to.eq(12.9);
   });
 });

--- a/featurehub-javascript-node-sdk/CHANGELOG.md
+++ b/featurehub-javascript-node-sdk/CHANGELOG.md
@@ -1,5 +1,3 @@
-#### 1.0.11
-- Provided additional getters to get feature values and properties [GitHub PR](https://github.com/featurehub-io/featurehub/pull/656/)
 #### 1.0.10
 - Fix a bug related to Catch & Release mode [GitHub issue](https://github.com/featurehub-io/featurehub/issues/648)
 #### 1.0.9


### PR DESCRIPTION
# Description

This reverts the API changes from version 1.0.11 which made
it incompatible with v3 of typescript. We will release a 1.1.1 which
requires Typescript 4.3.x+

