### PR TITLE
feat: adds removeListener/removeReadynessListener API interfaces

### DIFF
--- a/featurehub-javascript-client-sdk/app/client_feature_repository.ts
+++ b/featurehub-javascript-client-sdk/app/client_feature_repository.ts
@@ -144,6 +144,10 @@ export class ClientFeatureRepository implements InternalFeatureRepository {
     listener(this.readynessState);
   }
 
+  public removeReadynessListener(listenerToRemove: ReadynessListener): void {
+    this.readynessListeners = this.readynessListeners.filter((listener) => listener !== listenerToRemove);
+  }
+
   notReady(): void {
     this.readynessState = Readyness.NotReady;
     this.broadcastReadynessState();

--- a/featurehub-javascript-client-sdk/app/feature_state.ts
+++ b/featurehub-javascript-client-sdk/app/feature_state.ts
@@ -82,7 +82,11 @@ export interface FeatureStateHolder {
 
   get enabled(): boolean;
 
+  /** Adds listener to the subscription list */
   addListener(listener: FeatureListener): void;
+
+  /** Removes the listener from the subscription list */
+  removeListener(listener: FeatureListener): void;
 
   // this is intended for override repositories (such as the UserFeatureRepository)
   // to force the listeners to trigger if they detect an actual state change in their layer

--- a/featurehub-javascript-client-sdk/app/feature_state_holders.ts
+++ b/featurehub-javascript-client-sdk/app/feature_state_holders.ts
@@ -79,6 +79,10 @@ export class FeatureStateBaseHolder implements FeatureStateHolder {
     }
   }
 
+  public removeListener(listenerToRemove: FeatureListener): void {
+    this.listeners = this.listeners.filter((listener) => listener !== listenerToRemove);
+  }
+
   public getBoolean(): boolean | undefined {
     return this._getValue(FeatureValueType.Boolean) as boolean | undefined;
   }

--- a/featurehub-javascript-client-sdk/app/featurehub_repository.ts
+++ b/featurehub-javascript-client-sdk/app/featurehub_repository.ts
@@ -54,6 +54,8 @@ export interface FeatureHubRepository {
   addValueInterceptor(interceptor: FeatureStateValueInterceptor): void;
 
   addReadynessListener(listener: ReadynessListener): void;
+  
+  removeReadynessListener(listener: ReadynessListener): void;
 
   addAnalyticCollector(collector: AnalyticsCollector): void;
 

--- a/featurehub-javascript-client-sdk/app/local_context.ts
+++ b/featurehub-javascript-client-sdk/app/local_context.ts
@@ -63,6 +63,9 @@ class LocalFeatureRepository implements InternalFeatureRepository {
     listener(Readyness.Ready);
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  public removeReadynessListener(listener: ReadynessListener): void {}
+
   notReady(): void {
   }
 

--- a/featurehub-javascript-client-sdk/app/middleware.ts
+++ b/featurehub-javascript-client-sdk/app/middleware.ts
@@ -30,8 +30,10 @@ class BaggageHolder implements FeatureStateHolder {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  addListener(listener: FeatureListener): void {
-  }
+  addListener(listener: FeatureListener): void {}
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  removeListener(listener: FeatureListener): void {}
 
   getBoolean(): boolean | undefined {
     if (this.existing.isLocked()) {
@@ -245,6 +247,10 @@ class BaggageRepository implements InternalFeatureRepository {
 
   addReadynessListener(listener: ReadynessListener) {
     this.repo.addReadynessListener(listener);
+  }
+
+  removeReadynessListener(listener: ReadynessListener): void {
+    this.repo.removeReadynessListener(listener);
   }
 
   addAnalyticCollector(collector: AnalyticsCollector): void {


### PR DESCRIPTION
# Description

This PR adds two net new interfaces to support FeatureHub SDK use-cases that require cleanup of attached listeners. (e.g. React web apps where UI components can mount/unmount from view)

- `removeReadynessListener`
- `removeListener`

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
