### PR TITLE
fix: updates FeatureListener interface to be generic to retain type information

### DIFF
--- a/featurehub-javascript-client-sdk/app/feature_state.ts
+++ b/featurehub-javascript-client-sdk/app/feature_state.ts
@@ -3,9 +3,9 @@ import { ClientContext } from './client_context';
 
 // these two depend on each other
 
-export interface FeatureListener {
+export interface FeatureListener<T = any> {
   // eslint-disable-next-line no-use-before-define
-  (featureChanged: FeatureStateHolder): void;
+  (featureChanged: FeatureStateHolder<T>): void;
 }
 
 export type FeatureListenerHandle = number;
@@ -88,18 +88,18 @@ export interface FeatureStateHolder<T = any> {
    * Adds a new listener and returns a handle so that the listener can be removed.
    * @param listener
    */
-  addListener(listener: FeatureListener): FeatureListenerHandle;
+  addListener(listener: FeatureListener<T>): FeatureListenerHandle;
 
   /**
    * Allows the SDK client to remove the listener as part of a teardown
    * @param handle - removes it from the trigger list if it exists, otherwise ignored
    */
-  removeListener(handle: FeatureListener | FeatureListenerHandle);
+  removeListener(handle: FeatureListener<T> | FeatureListenerHandle);
 
   // this is intended for override repositories (such as the UserFeatureRepository)
   // to force the listeners to trigger if they detect an actual state change in their layer
   // it passes in the feature state holder to notify with
-  triggerListeners(feature?: FeatureStateHolder): void;
+  triggerListeners(feature?: FeatureStateHolder<T>): void;
 
   /** the value of the feature flag */
   get value(): T;

--- a/featurehub-javascript-client-sdk/app/feature_state_holders.ts
+++ b/featurehub-javascript-client-sdk/app/feature_state_holders.ts
@@ -72,7 +72,7 @@ export class FeatureStateBaseHolder<T = any> implements FeatureStateHolder<T> {
     return this.getBoolean() === true;
   }
 
-  public addListener(listener: FeatureListener): FeatureListenerHandle {
+  public addListener(listener: FeatureListener<T>): FeatureListenerHandle {
     const pos = ListenerUtils.newListenerKey(this.listeners);
 
     if (this._ctx !== undefined) {
@@ -84,7 +84,7 @@ export class FeatureStateBaseHolder<T = any> implements FeatureStateHolder<T> {
     return pos;
   }
 
-  public removeListener(handle: FeatureListener | FeatureListenerHandle) {
+  public removeListener(handle: FeatureListener<T> | FeatureListenerHandle) {
     ListenerUtils.removeListener(this.listeners, handle);
   }
 
@@ -193,7 +193,7 @@ export class FeatureStateBaseHolder<T = any> implements FeatureStateHolder<T> {
     return this.internalFeatureState;
   }
 
-  private _getValue(type?: FeatureValueType, parseJson: boolean = false): any | undefined {
+  private _getValue(type?: FeatureValueType, parseJson = false): any | undefined {
     if (!this.isLocked()) {
       const intercept = this._repo.valueInterceptorMatched(this._key);
 
@@ -218,7 +218,7 @@ export class FeatureStateBaseHolder<T = any> implements FeatureStateHolder<T> {
     return featureState?.value;
   }
 
-  private _castType(type: FeatureValueType, value: any, parseJson: boolean = false): any | undefined {
+  private _castType(type: FeatureValueType, value: any, parseJson = false): any | undefined {
     if (value == null) {
       return undefined;
     }

--- a/featurehub-javascript-client-sdk/app/middleware.ts
+++ b/featurehub-javascript-client-sdk/app/middleware.ts
@@ -31,11 +31,11 @@ class BaggageHolder<T = any> implements FeatureStateHolder<T> {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  addListener(listener: FeatureListener): FeatureListenerHandle {
+  addListener(listener: FeatureListener<T>): FeatureListenerHandle {
     return 0;
   }
 
-  removeListener(handle:FeatureListener | FeatureListenerHandle) {
+  removeListener(handle: FeatureListener<T> | FeatureListenerHandle) {
   }
 
   getBoolean(): boolean | undefined {


### PR DESCRIPTION
# Description

This PR updates the `FeatureListener` interface to support use of TypeScript generics. The motivation was that I noticed type information was lost whenever a listener was added to a feature key and that should not be the case once you supply the generic type to the top-level `context.feature<T>(key)` invocation.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Local inspection of `addListener` invocation ensuring type information is retained

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
