### PR TITLE
refactor(solid-sdk): refines implementation of the FeatureHub Solid SDK

### DIFF
--- a/examples/todo-frontend-solid-sdk/package-lock.json
+++ b/examples/todo-frontend-solid-sdk/package-lock.json
@@ -20,7 +20,7 @@
     },
     "../../featurehub-solid-sdk": {
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT",
       "devDependencies": {
         "@types/node": "^18.11.18",
         "@typescript-eslint/eslint-plugin": "^5.48.1",
@@ -30,9 +30,7 @@
         "eslint-plugin-solid": "^0.9.2",
         "prettier": "2.8.2",
         "tsup": "6.5.0",
-        "typescript": "^4.9.4",
-        "vite": "^4.0.4",
-        "vite-plugin-solid": "^2.5.0"
+        "typescript": "^4.9.4"
       },
       "peerDependencies": {
         "featurehub-javascript-client-sdk": "^1.1.7",
@@ -2260,9 +2258,7 @@
         "eslint-plugin-solid": "^0.9.2",
         "prettier": "2.8.2",
         "tsup": "6.5.0",
-        "typescript": "^4.9.4",
-        "vite": "^4.0.4",
-        "vite-plugin-solid": "^2.5.0"
+        "typescript": "^4.9.4"
       }
     },
     "fsevents": {

--- a/examples/todo-frontend-solid-sdk/src/App.tsx
+++ b/examples/todo-frontend-solid-sdk/src/App.tsx
@@ -1,11 +1,11 @@
-import { Component, createSignal, createEffect } from 'solid-js';
+import { Component, createSignal, createEffect } from "solid-js";
 
-import logoSolid from './logo.svg';
-import logoVite from './vite.svg';
-import styles from './App.module.css';
-import { FeatureHub, useFeature } from 'featurehub-solid-sdk'
+import logoSolid from "./logo.svg";
+import logoVite from "./vite.svg";
+import styles from "./App.module.css";
+import { FeatureHub, useFeature } from "featurehub-solid-sdk";
 
-const SAMPLE_TEXT = "This is some random text content which may have its case-sensitivity modified."
+const SAMPLE_TEXT = "This is some random text content which may have its case-sensitivity modified.";
 
 /*
   DEVELOPER NOTE:
@@ -21,12 +21,13 @@ function App() {
   const [userKey, setUserKey] = createSignal("");
 
   setTimeout(() => {
+    console.log("ASSIGNING USER AFTER DELAY!");
     // Set username after arbitrary delay to make sure FeatureHub component reconfigures its internals properly.
-    setUserKey("john.doe")
-  }, 1000)
+    setUserKey("john.doe");
+  }, 1000);
 
   return (
-     /*
+    /*
         To run a local instance of FeatureHub for testing, run either of the following commands:
         - docker run -p 8085:8085 --user 999:999 -v $HOME/.featurehub/party/db featurehub/party-server:latest
         - podman run -p 8085:8085 --user 999:999 -v $HOME/.featurehub/party/db featurehub/party-server:latest
@@ -34,15 +35,10 @@ function App() {
         Once you go through the intial setup wizard/guide to create a service account + permissions, 
         go to API Keys for the service account, copy the 'Server eval API key' and paste it into the apiKey prop below.
       */
-    <FeatureHub
-      url='http://localhost:8085'
-      apiKey=''
-      userKey={userKey()}
-      pollInterval={5000}
-    >
+    <FeatureHub url="http://localhost:8085" apiKey="" userKey={userKey()} pollInterval={5000}>
       <Main />
     </FeatureHub>
-  )
+  );
 }
 
 function Main() {
@@ -60,11 +56,11 @@ function Main() {
 
   const shouldUpperCaseText = useFeature("uppercase_text");
   const textColour = useFeature<string>("text_colour");
-  const [displayText, setDisplayText] = createSignal(SAMPLE_TEXT)
+  const [displayText, setDisplayText] = createSignal(SAMPLE_TEXT);
 
   createEffect(() => {
     setDisplayText(shouldUpperCaseText() ? SAMPLE_TEXT.toUpperCase() : SAMPLE_TEXT);
-  }, [shouldUpperCaseText])
+  }, [shouldUpperCaseText]);
 
   return (
     <div class={styles.header}>
@@ -78,27 +74,29 @@ function Main() {
       </div>
       <h1>Vite + Solid</h1>
       <div class={styles.content}>
+        <div class={styles.card}>
+          <p>
+            Edit <code>src/App.tsx</code> and save to test HMR
+          </p>
 
-      <div class={styles.card}>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
+          <button onClick={() => setCount(count() + 1)}>Count: {count()}</button>
 
-        <button onClick={() => setCount(count() + 1)}>Count: {count()}</button>
+          <p>
+            The value of <code>uppercase_text</code> feature is <code>{`${shouldUpperCaseText()}`}</code>
+          </p>
+          <p>
+            The value of <code>text_colour</code> feature is <code>{textColour()}</code>
+          </p>
 
-        <p>The value of <code>uppercase_text</code> feature is <code>{`${shouldUpperCaseText()}`}</code></p>
-        <p>The value of <code>text_colour</code> feature is <code>{textColour()}</code></p>
-        
-        <p style={{ color: textColour()} }>This paragraph color should be {textColour()}</p>
-        <p>{displayText()}</p>
-      </div>
-      <div >
-        <p class={styles.readTheDocs}>Click on the Vite and Solid logos to learn more</p>
-      </div>
+          <p style={{ color: textColour() }}>This paragraph color should be {textColour()}</p>
+          <p>{displayText()}</p>
+        </div>
+        <div>
+          <p class={styles.readTheDocs}>Click on the Vite and Solid logos to learn more</p>
+        </div>
       </div>
     </div>
-  )
+  );
 }
 
-export default App
-
+export default App;

--- a/featurehub-solid-sdk/src/hooks/useFeature.tsx
+++ b/featurehub-solid-sdk/src/hooks/useFeature.tsx
@@ -1,4 +1,5 @@
 import { Accessor, createEffect, createSignal, onCleanup, on } from "solid-js";
+import { ready } from "../components/FeatureHub";
 import useFeatureHub from "./useFeatureHub";
 
 /**
@@ -15,8 +16,13 @@ function useFeature<T = boolean>(key: string): Accessor<T> {
   const [value, setValue] = createSignal(client().feature<T>(key).value);
 
   createEffect(
-    on(client, () => {
-      if (listenerId) client().feature<T>(key).removeListener(listenerId);
+    on(ready, () => {
+      // Being proper, we only subscribe to features when FeatureHub is ready
+      if (!ready()) return;
+
+      if (listenerId) {
+        client().feature<T>(key).removeListener(listenerId);
+      }
 
       listenerId = client()
         .feature<T>(key)

--- a/featurehub-solid-sdk/src/hooks/useFeatureHub.tsx
+++ b/featurehub-solid-sdk/src/hooks/useFeatureHub.tsx
@@ -6,15 +6,15 @@ import { FeatureHubContext, UseFeatureHub } from "../components/FeatureHub";
  * @returns {UseFeatureHub} - struct containing both the FeatureHub config and client
  */
 function useFeatureHub(): UseFeatureHub {
-  const { config, client } = useContext(FeatureHubContext);
+  const featureHub = useContext(FeatureHubContext);
 
-  if (!config() || !client()) {
+  if (!featureHub) {
     throw new Error(
       "Error invoking useFeatureHub! Make sure your component is wrapped by the top-level <FeatureHub> component!"
     );
   }
 
-  return { config, client };
+  return featureHub;
 }
 
 export default useFeatureHub;


### PR DESCRIPTION
# Description

Refines the implementation details of the Solid SDK. Makes use of the `createMemo` primitive to eagerly create the FeatureHub config object to be in better alignment with Solid's reactive core/graph. 

Vast majority of the changes are in `FeatureHub.tsx`.

This should generate a patch release `v1.0.1` of the SDK when it gets merged

## Type of change

- [x] Refactor / housekeeping

# How Has This Been Tested?

- [x] Smoketest against example app

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
