### PR TITLE
[internal/four-style-testing] Allow env to configure connection type

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+**/node_modules
+.git
+.husky
+**/dist
+**/lib

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:18-buster-slim as build
+
+ADD . /app
+WORKDIR /app
+RUN cd /app/featurehub-javascript-client-sdk && npm install && npm run compile
+RUN cd /app/featurehub-javascript-node-sdk  && npm install && npm run link && npm run compile
+RUN cd /app/examples/todo-server-tests && npm install && npm run compile
+RUN cd /app/examples/todo-backend-typescript && npm install && npm run compile
+

--- a/examples/todo-backend-typescript/app/app.ts
+++ b/examples/todo-backend-typescript/app/app.ts
@@ -4,7 +4,7 @@ import { ITodoApiController, Todo, TodoApiRouter } from "./generated-interface";
 import {
   ClientContext,
   EdgeFeatureHubConfig,
-  featurehubMiddleware,
+  featurehubMiddleware, FeatureHubPollingClient, FHLog,
   Readyness,
   StrategyAttributeCountryName,
   StrategyAttributeDeviceName,
@@ -19,12 +19,17 @@ if (process.env.FEATUREHUB_EDGE_URL === undefined || process.env.FEATUREHUB_CLIE
 //provide EDGE_URL, e.g. 'http://localhost:8553/'
 //provide API_KEY, e.g. default/ff8635ef-ed28-4cc3-8067-b9ffd8882100/lOopBkGPALBcI0p6AGpf4jAdUi2HxR0RkhYvV00i1XsMQLWkltaoFvEfs7uFsZaQ45kF5FmhGE7rWTSg'
 
-// fhLog.trace = (...args: any) => console.log(args);
+FHLog.fhLog.trace = (...args: any) => console.log(args);
 const fhConfig = new EdgeFeatureHubConfig(process.env.FEATUREHUB_EDGE_URL, process.env.FEATUREHUB_CLIENT_API_KEY);
 
 fhConfig.addReadinessListener((ready, firstTime) => {
 
 }, true);
+
+if (process.env.FEATUREHUB_POLLING_INTERVAL) {
+  fhConfig.edgeServiceProvider((repo, config) =>
+    new FeatureHubPollingClient(repo, config, parseInt(process.env.FEATUREHUB_POLLING_INTERVAL)));
+}
 
 // Add override to use polling client
 // const FREQUENCY = 5000; // 5 seconds

--- a/examples/todo-backend-typescript/package.json
+++ b/examples/todo-backend-typescript/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "node_modules/.bin/tsc",
     "link": "npm link featurehub-javascript-client-sdk featurehub-javascript-node-sdk",
+		"compile": "npm run link && npm run build",
     "start": "npm run build && node --trace-deprecation --trace-warnings dist/app.js",
     "run": "npm run build && node --trace-deprecation --trace-warnings dist/app.js"
   },

--- a/examples/todo-server-tests/features/boolean-flag.feature
+++ b/examples/todo-server-tests/features/boolean-flag.feature
@@ -15,13 +15,16 @@ Feature: Checks boolean flag
     When I have added a new to-do item "Buy eggs"
     Then my list of todos should contain "Buy eggs"
 
-  @bool
+  @bool @flaglock  @flaglockparty
   Scenario: Check boolean flag lock function
-    Given I lock the feature "FEATURE_TITLE_TO_UPPERCASE"
+    Given I set the flag "FEATURE_TITLE_TO_UPPERCASE" to "true"
+    Then feature FEATURE_TITLE_TO_UPPERCASE is unlocked and "on"
+    And I lock the feature "FEATURE_TITLE_TO_UPPERCASE"
+    Then feature FEATURE_TITLE_TO_UPPERCASE is locked and "on"
     When I attempt to update feature "FEATURE_TITLE_TO_UPPERCASE" to boolean value "false"
     Then I should not be able to update the value
 
-  @bool
+  @bool   @flaglockparty
   Scenario: Check boolean flag cannot be updated with string values
     Given I set the flag "FEATURE_TITLE_TO_UPPERCASE" to "foo"
     Then I should not be able to update the value

--- a/examples/todo-server-tests/features/json-value.feature
+++ b/examples/todo-server-tests/features/json-value.feature
@@ -1,3 +1,4 @@
+@FEATURE_TITLE_TO_UPPERCASE_OFF
 Feature: Checks json feature
 
   @FEATURE_JSON_BAR

--- a/examples/todo-server-tests/features/number-value.feature
+++ b/examples/todo-server-tests/features/number-value.feature
@@ -1,3 +1,4 @@
+@FEATURE_TITLE_TO_UPPERCASE_OFF
 Feature: Checks number feature
 
   @FEATURE_NUMBER_1  @number
@@ -35,9 +36,12 @@ Feature: Checks number feature
     When I have added a new to-do item "pay"
     Then my list of todos should contain "pay"
 
-  @number
+  @number @numberlock
   Scenario: Check number lock function
-    Given I lock the feature "FEATURE_NUMBER"
+    Given I set the flag "FEATURE_NUMBER" to "26"
+    Then feature FEATURE_NUMBER is unlocked and "26"
+    And I lock the feature "FEATURE_NUMBER"
+    Then feature FEATURE_NUMBER is locked and "26"
     When I attempt to update feature "FEATURE_NUMBER" to number value "35"
     Then I should not be able to update the value
 

--- a/examples/todo-server-tests/features/string-value.feature
+++ b/examples/todo-server-tests/features/string-value.feature
@@ -1,3 +1,4 @@
+@FEATURE_TITLE_TO_UPPERCASE_OFF
 Feature: Checks string feature
 
   @FEATURE_STRING_MILK
@@ -35,8 +36,12 @@ Feature: Checks string feature
     When I have added a new to-do item "buy"
     Then my list of todos should contain "buy"
 
+    @stringlock
   Scenario: Check string lock function
-    Given I lock the feature "FEATURE_STRING"
+    And I set the flag "FEATURE_STRING" to "ugg-boots"
+    Then feature FEATURE_STRING is unlocked and "ugg-boots"
+    And I lock the feature "FEATURE_STRING"
+    Then feature FEATURE_STRING is locked and "ugg-boots"
     When I attempt to update feature "FEATURE_STRING" to string value "run"
     Then I should not be able to update the value
 

--- a/examples/todo-server-tests/features/support/config.ts
+++ b/examples/todo-server-tests/features/support/config.ts
@@ -1,26 +1,32 @@
-import {EdgeFeatureHubConfig, FeatureHubPollingClient} from "featurehub-javascript-node-sdk";
+import { EdgeFeatureHubConfig, FeatureHubPollingClient, FHLog } from "featurehub-javascript-node-sdk";
 
 function getApplicationServerUrl(): string {
-    let appUrl;
+  let appUrl;
 
-    if (process.env.FEATUREHUB_EDGE_URL === undefined || process.env.FEATUREHUB_CLIENT_API_KEY === undefined) {
-        console.error('You must define the Application server URL under test in the environment variable FEATUREHUB_EDGE_URL and the API key in FEATUREHUB_CLIENT_API_KEY');
-        process.exit(-1);
-    } else appUrl = process.env.APP_SERVER_URL;
+  if (process.env.FEATUREHUB_EDGE_URL === undefined || process.env.FEATUREHUB_CLIENT_API_KEY === undefined) {
+    console.error('You must define the Application server URL under test in the environment variable FEATUREHUB_EDGE_URL and the API key in FEATUREHUB_CLIENT_API_KEY');
+    process.exit(-1);
+  } else appUrl = process.env.APP_SERVER_URL;
 
-    return appUrl;
+  return appUrl;
 }
 
 function getFhConfig(): EdgeFeatureHubConfig {
-    const fhConfig  = new EdgeFeatureHubConfig(process.env.FEATUREHUB_EDGE_URL, process.env.FEATUREHUB_CLIENT_API_KEY);
-    // Uncomment for polling client method
-    // fhConfig.edgeServiceProvider((repo, c) =>
-    //     new FeatureHubPollingClient(repo, c, 2000));
-    fhConfig.init();
-    return fhConfig;
+  const fhConfig = new EdgeFeatureHubConfig(process.env.FEATUREHUB_EDGE_URL, process.env.FEATUREHUB_CLIENT_API_KEY);
+
+  if (process.env.FEATUREHUB_POLLING_INTERVAL) {
+    fhConfig.edgeServiceProvider((repo, config) =>
+      new FeatureHubPollingClient(repo, config, parseInt(process.env.FEATUREHUB_POLLING_INTERVAL)));
+  }
+
+  FHLog.fhLog.trace = (...args: any[]) => { console.log(args); }
+
+  fhConfig.init();
+
+  return fhConfig;
 }
 
 export class Config {
-    public static baseApplicationPath = getApplicationServerUrl();
-    public static fhConfig = getFhConfig();
+  public static baseApplicationPath = getApplicationServerUrl();
+  public static fhConfig = getFhConfig();
 }

--- a/examples/todo-server-tests/features/support/hooks.ts
+++ b/examples/todo-server-tests/features/support/hooks.ts
@@ -1,3 +1,5 @@
+import { CustomWorld } from './world';
+
 const {Before, After} = require("@cucumber/cucumber");
 import {
   FeatureUpdater,
@@ -7,86 +9,79 @@ import {
 import { Config } from "./config";
 import { expect } from "chai";
 
+Before(function(details: any) {
+  if (process.env.DEBUG) {
+    console.log(`------------- (started ${details?.pickle?.name})`);
+  }
+});
+
+After(function(details: any) {
+  if (process.env.DEBUG) {
+    console.log(`******* (finished ${details?.pickle?.name})`);
+  }
+});
+
 Before({tags: "@FEATURE_TITLE_TO_UPPERCASE"}, async function () {
-  await updateFeature('FEATURE_TITLE_TO_UPPERCASE', true);
+  await (this as CustomWorld).updateFeature('FEATURE_TITLE_TO_UPPERCASE', true);
 });
 
 After({tags: "@FEATURE_TITLE_TO_UPPERCASE"}, async function () {
-  await updateFeature('FEATURE_TITLE_TO_UPPERCASE', false);
+  await (this as CustomWorld).updateFeature('FEATURE_TITLE_TO_UPPERCASE', false);
 });
 
 Before({tags: "@FEATURE_TITLE_TO_UPPERCASE_OFF"}, async function () {
-  await updateFeature('FEATURE_TITLE_TO_UPPERCASE', false);
+  await (this as CustomWorld).updateFeature('FEATURE_TITLE_TO_UPPERCASE', false);
 });
 
 Before({tags: "@FEATURE_STRING_MILK"}, async function () {
-  await updateFeature('FEATURE_STRING', 'milk');
+  await (this as CustomWorld).updateFeature('FEATURE_STRING', 'milk');
 });
 
 Before({tags: "@FEATURE_STRING_BREAD"}, async function () {
-  await updateFeature('FEATURE_STRING', 'bread');
+  await (this as CustomWorld).updateFeature('FEATURE_STRING', 'bread');
 });
 
 Before({tags: "@FEATURE_STRING_MULTI"}, async function () {
-  await updateFeature('FEATURE_STRING', 'foo bar baz');
+  await (this as CustomWorld).updateFeature('FEATURE_STRING', 'foo bar baz');
 });
 
 Before({tags: "@FEATURE_STRING_EMPTY"}, async function () {
-  await updateFeature('FEATURE_STRING', '');
+  await (this as CustomWorld).updateFeature('FEATURE_STRING', '');
 });
 
 Before({tags: "@FEATURE_STRING_NULL"}, async function () {
-  await setFeatureToNotSet('FEATURE_STRING');
+  await (this as CustomWorld).setFeatureToNotSet('FEATURE_STRING');
 });
 
 Before({tags: "@FEATURE_NUMBER_1"}, async function () {
-  await updateFeature('FEATURE_NUMBER', 1);
+  await (this as CustomWorld).updateFeature('FEATURE_NUMBER', 1);
 });
 
 Before({tags: "@FEATURE_NUMBER_DEC"}, async function () {
-  await updateFeature('FEATURE_NUMBER', 507598.258978);
+  await (this as CustomWorld).updateFeature('FEATURE_NUMBER', 507598.258978);
 });
 
 Before({tags: "@FEATURE_NUMBER_NEG"}, async function () {
-  await updateFeature('FEATURE_NUMBER', -16746.43);
+  await (this as CustomWorld).updateFeature('FEATURE_NUMBER', -16746.43);
 });
 
 Before({tags: "@FEATURE_NUMBER_ZERO"}, async function () {
-  await updateFeature('FEATURE_NUMBER', 0);
+  await (this as CustomWorld).updateFeature('FEATURE_NUMBER', 0);
 });
 
 Before({tags: "@FEATURE_JSON_BAR"}, async function () {
-  await updateFeature('FEATURE_JSON', JSON.stringify({foo: "bar"}));
+  await (this as CustomWorld).updateFeature('FEATURE_JSON', JSON.stringify({foo: "bar"}));
 });
 
 Before({tags: "@FEATURE_JSON_BAZ"}, async function () {
-  await updateFeature('FEATURE_JSON', JSON.stringify({foo: "baz"}));
+  await (this as CustomWorld).updateFeature('FEATURE_JSON', JSON.stringify({foo: "baz"}));
 });
 
 Before({tags: "@FEATURE_NUMBER_NULL"}, async function () {
-  await setFeatureToNotSet('FEATURE_NUMBER');
+  await (this as CustomWorld).setFeatureToNotSet('FEATURE_NUMBER');
 });
 
 Before({tags: "@FEATURE_JSON_NULL"}, async function () {
-  await setFeatureToNotSet('FEATURE_JSON');
+  await (this as CustomWorld).setFeatureToNotSet('FEATURE_JSON');
 });
 
-async function updateFeature(name: string, newValue: any) {
-  const featureUpdater = new FeatureUpdater(Config.fhConfig);
-
-  const response = await featureUpdater.updateKey(name, {
-    lock: false,
-    value: newValue,
-  } as FeatureStateUpdate);
-  console.log(`Feature ${name}: lock: false, new value ${newValue}, response is ${response}`);
-  expect(response).to.equal(true);
-}
-
-async function setFeatureToNotSet(name: string) {
-  const featureUpdater = new FeatureUpdater(Config.fhConfig);
-  const response = await featureUpdater.updateKey(name, {
-    lock: false,
-    updateValue: true
-  } as FeatureStateUpdate);
-  console.log(`Feature ${name}: lock: false, clear feature, response is ${response}`);
-}

--- a/examples/todo-server-tests/package.json
+++ b/examples/todo-server-tests/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "node ./node_modules/typescript/bin/tsc",
 		"link": "npm link featurehub-javascript-client-sdk featurehub-javascript-node-sdk",
+		"compile": "npm run link && npm run build",
     "test": "cucumber-js --require-module ts-node/register --require 'features/support/*.ts' --publish",
     "generate:specs": "openapi-generator-cli generate -g typescript-axios -i ../todo-api/todo-api.yaml -o ./src/client-axios"
   },

--- a/featurehub-javascript-client-sdk/app/featurehub_eventsource.ts
+++ b/featurehub-javascript-client-sdk/app/featurehub_eventsource.ts
@@ -83,7 +83,7 @@ export class FeatureHubEventSourceClient implements EdgeService {
       };
     }
 
-    fhLog.log('listening at ', this._config.url());
+    fhLog.trace('listening at ', this._config.url());
 
     this.eventSource = FeatureHubEventSourceClient.eventSourceProvider(this._config.url(), options);
 

--- a/featurehub-javascript-client-sdk/app/polling_sdk.ts
+++ b/featurehub-javascript-client-sdk/app/polling_sdk.ts
@@ -91,7 +91,7 @@ export class BrowserPollingService extends PollingBase implements PollingService
   private readonly _options: BrowserOptions;
   private localStorageLastUrl: string | undefined;
 
-  // override this with a replacement if you need to
+  // override this with a replacement if you need to, for example to add any headers.
   static httpRequestor = () => {
     return new XMLHttpRequest();
   };
@@ -226,7 +226,7 @@ export class FeatureHubPollingClient implements EdgeService {
           (e) =>
             this.response(e));
 
-      fhLog.log(`featurehub: initialized polling client to ${this._url}`);
+      fhLog.trace(`featurehub: initialized polling client to ${this._url}`);
     }
   }
 

--- a/featurehub-javascript-client-sdk/app/test_sdk.ts
+++ b/featurehub-javascript-client-sdk/app/test_sdk.ts
@@ -26,7 +26,7 @@ export type FeatureUpdaterProvider = () => FeatureUpdatePostManager;
 
 export class FeatureUpdater {
   private sdkUrl: string;
-  private manager: FeatureUpdatePostManager;
+  public readonly manager: FeatureUpdatePostManager;
 
   public static featureUpdaterProvider: FeatureUpdaterProvider = () => new BrowserFeaturePostUpdater();
 

--- a/make-image.sh
+++ b/make-image.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker build -t featurehub/js-sdk:1.0 .


### PR DESCRIPTION
# Description

Mostly fixes in ensuring that the tests can be run via environment variables in polling or SSE mode so they can be automated for every variant of featurehub-installs.

Also moves logging of API key to trace level.

Fixes #157 
