### PR TITLE
[internal/out-of-order-delete] Fixup where you can get out of order deletes

### DIFF
--- a/examples/todo-server-tests/features/support/hooks.ts
+++ b/examples/todo-server-tests/features/support/hooks.ts
@@ -3,11 +3,12 @@ import { CustomWorld } from './world';
 const {Before, After} = require("@cucumber/cucumber");
 import {
   FeatureUpdater,
-  FeatureStateUpdate,
+  FeatureStateUpdate, ClientContext,
 
 } from "featurehub-javascript-node-sdk";
 import { Config } from "./config";
 import { expect } from "chai";
+import waitForExpect from 'wait-for-expect';
 
 Before(function(details: any) {
   if (process.env.DEBUG) {
@@ -23,65 +24,127 @@ After(function(details: any) {
 
 Before({tags: "@FEATURE_TITLE_TO_UPPERCASE"}, async function () {
   await (this as CustomWorld).updateFeature('FEATURE_TITLE_TO_UPPERCASE', true);
+  await awaitCompletionOfChange((ctx: ClientContext) => {
+    expect(ctx.feature('FEATURE_TITLE_TO_UPPERCASE').flag).to.eq(true);
+  });
 });
 
 After({tags: "@FEATURE_TITLE_TO_UPPERCASE"}, async function () {
   await (this as CustomWorld).updateFeature('FEATURE_TITLE_TO_UPPERCASE', false);
+  await awaitCompletionOfChange((ctx: ClientContext) => {
+    expect(ctx.feature('FEATURE_TITLE_TO_UPPERCASE').flag).to.eq(false);
+  });
 });
 
 Before({tags: "@FEATURE_TITLE_TO_UPPERCASE_OFF"}, async function () {
   await (this as CustomWorld).updateFeature('FEATURE_TITLE_TO_UPPERCASE', false);
+  await awaitCompletionOfChange((ctx: ClientContext) => {
+    expect(ctx.feature('FEATURE_TITLE_TO_UPPERCASE').flag).to.eq(false);
+  });
+
 });
 
 Before({tags: "@FEATURE_STRING_MILK"}, async function () {
   await (this as CustomWorld).updateFeature('FEATURE_STRING', 'milk');
+  await awaitCompletionOfChange((ctx: ClientContext) => {
+    expect(ctx.feature('FEATURE_STRING').str).to.eq('milk');
+  });
 });
 
 Before({tags: "@FEATURE_STRING_BREAD"}, async function () {
   await (this as CustomWorld).updateFeature('FEATURE_STRING', 'bread');
+  await awaitCompletionOfChange((ctx: ClientContext) => {
+    expect(ctx.feature('FEATURE_STRING').str).to.eq('bread');
+  });
 });
 
 Before({tags: "@FEATURE_STRING_MULTI"}, async function () {
   await (this as CustomWorld).updateFeature('FEATURE_STRING', 'foo bar baz');
+  await awaitCompletionOfChange((ctx: ClientContext) => {
+    expect(ctx.feature('FEATURE_STRING').str).to.eq('foo bar baz');
+  });
 });
 
 Before({tags: "@FEATURE_STRING_EMPTY"}, async function () {
   await (this as CustomWorld).updateFeature('FEATURE_STRING', '');
+  await awaitCompletionOfChange((ctx: ClientContext) => {
+    expect(ctx.feature('FEATURE_STRING').isSet()).to.not.be.true;
+  });
+
 });
 
 Before({tags: "@FEATURE_STRING_NULL"}, async function () {
   await (this as CustomWorld).setFeatureToNotSet('FEATURE_STRING');
+  await awaitCompletionOfChange((ctx: ClientContext) => {
+    expect(ctx.feature('FEATURE_STRING').isSet()).to.not.be.true;
+  })
 });
 
 Before({tags: "@FEATURE_NUMBER_1"}, async function () {
   await (this as CustomWorld).updateFeature('FEATURE_NUMBER', 1);
+  await awaitCompletionOfChange((ctx: ClientContext) => {
+    expect(ctx.feature('FEATURE_NUMBER').num).to.eq(1);
+  })
 });
 
 Before({tags: "@FEATURE_NUMBER_DEC"}, async function () {
   await (this as CustomWorld).updateFeature('FEATURE_NUMBER', 507598.258978);
+  await awaitCompletionOfChange((ctx: ClientContext) => {
+    expect(ctx.feature('FEATURE_NUMBER').num).to.eq(507598.258978);
+  })
 });
+
+async function awaitCompletionOfChange(expectFunc: (ctx: ClientContext) => void) {
+  const ctx = await Config.fhConfig.newContext().build();
+
+  const timeout = process.env.FEATUREHUB_POLLING_INTERVAL ? (parseInt(process.env.FEATUREHUB_POLLING_INTERVAL) + 4000) : 7000;
+  await waitForExpect(async () => {
+    expectFunc(ctx);
+  }, timeout, 2000);
+}
 
 Before({tags: "@FEATURE_NUMBER_NEG"}, async function () {
   await (this as CustomWorld).updateFeature('FEATURE_NUMBER', -16746.43);
+  await awaitCompletionOfChange((ctx: ClientContext) => {
+    expect(ctx.feature('FEATURE_NUMBER').num).to.eq(-16746.43);
+  })
 });
 
 Before({tags: "@FEATURE_NUMBER_ZERO"}, async function () {
   await (this as CustomWorld).updateFeature('FEATURE_NUMBER', 0);
+  await awaitCompletionOfChange((ctx: ClientContext) => {
+    expect(ctx.feature('FEATURE_NUMBER').num).to.eq(0);
+  })
 });
 
 Before({tags: "@FEATURE_JSON_BAR"}, async function () {
-  await (this as CustomWorld).updateFeature('FEATURE_JSON', JSON.stringify({foo: "bar"}));
+  const json = JSON.stringify({foo: "bar"});
+  await (this as CustomWorld).updateFeature('FEATURE_JSON', json);
+  await awaitCompletionOfChange((ctx: ClientContext) => {
+    expect(ctx.feature('FEATURE_JSON').rawJson).to.eq(json);
+  })
 });
 
 Before({tags: "@FEATURE_JSON_BAZ"}, async function () {
-  await (this as CustomWorld).updateFeature('FEATURE_JSON', JSON.stringify({foo: "baz"}));
+  const json = JSON.stringify({foo: "baz"});
+  await (this as CustomWorld).updateFeature('FEATURE_JSON', json);
+  await awaitCompletionOfChange((ctx: ClientContext) => {
+    expect(ctx.feature('FEATURE_JSON').rawJson).to.eq(json);
+  })
+
 });
 
 Before({tags: "@FEATURE_NUMBER_NULL"}, async function () {
   await (this as CustomWorld).setFeatureToNotSet('FEATURE_NUMBER');
+  await awaitCompletionOfChange((ctx: ClientContext) => {
+    expect(ctx.feature('FEATURE_NUMBER').isSet()).to.not.be.true;
+  })
 });
 
 Before({tags: "@FEATURE_JSON_NULL"}, async function () {
   await (this as CustomWorld).setFeatureToNotSet('FEATURE_JSON');
+  await awaitCompletionOfChange((ctx: ClientContext) => {
+    expect(ctx.feature('FEATURE_JSON').isSet()).to.not.be.true;
+  })
 });
 

--- a/examples/todo-server-tests/features/support/world.ts
+++ b/examples/todo-server-tests/features/support/world.ts
@@ -36,6 +36,7 @@ export const responseToRecord = function (response: AxiosResponse) {
 };
 
 let requestId: number = 1;
+const reqIdPrefix = (process.env.REQUEST_ID_PREFIX || '');
 
 export class CustomWorld {
   private variable: number;
@@ -112,7 +113,7 @@ export class CustomWorld {
   addRequestIdHeaderToFeatureUpdater(): FeatureUpdater {
     const updater = new FeatureUpdater(Config.fhConfig);
     (updater.manager as NodejsFeaturePostUpdater).modifyRequestFunction = (req) => {
-      req.headers['Baggage'] = `cuke-req-id=${requestId}`;
+      req.headers['Baggage'] = `cuke-req-id=${reqIdPrefix}${requestId}`;
       requestId ++;
     }
     return updater;

--- a/featurehub-javascript-client-sdk/CHANGELOG.md
+++ b/featurehub-javascript-client-sdk/CHANGELOG.md
@@ -1,3 +1,5 @@
+#### 1.3.1
+- Edge case where a feature is retired and then unretired immediately, this _can_ cause the feature to stay deleted.
 #### 1.3.0
 - This surfaces a fully statically typed API for Typescript clients who enforce it. Of particular interest
 is the places where `undefined` can be returned. 

--- a/featurehub-javascript-client-sdk/app/client_feature_repository.ts
+++ b/featurehub-javascript-client-sdk/app/client_feature_repository.ts
@@ -367,7 +367,9 @@ export class ClientFeatureRepository implements InternalFeatureRepository {
   private deleteFeature(featureState: FeatureState) {
     const holder = this.features.get(featureState.key);
 
-    if (holder) {
+    // because of parallelism we can received retired features after they have been unretired
+    // so we need to check their versions
+    if (holder && ((featureState.version === undefined) || (featureState.version >= holder.version))) {
       holder.setFeatureState(undefined);
     }
   }

--- a/featurehub-javascript-client-sdk/package.json
+++ b/featurehub-javascript-client-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "featurehub-javascript-client-sdk",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "FeatureHub client/browser SDK",
   "author": "info@featurehub.io",
   "sideEffects": false,


### PR DESCRIPTION
# Description

There is a situation where you can get out of order deletes in Google Pub/Sub under test, where a feature is created, retired and then unretired. This resolves that issue.
