### PR TITLE
Update children type to be ReactNode

### DIFF
--- a/featurehub-react-sdk/src/components/FeatureHub.tsx
+++ b/featurehub-react-sdk/src/components/FeatureHub.tsx
@@ -1,4 +1,4 @@
-import { createContext, useEffect, useMemo, useRef, useState } from "react";
+import { createContext, ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import {
   ClientContext,
   EdgeFeatureHubConfig,
@@ -31,7 +31,7 @@ type Props = {
   /** Interval (in milliseconds) to poll FeatureHub for updates. [default: 60 seconds] */
   readonly pollInterval?: number;
   /** The React application tree to inject the FeatureHub client into */
-  readonly children: JSX.Element;
+  readonly children: ReactNode;
 };
 
 /**


### PR DESCRIPTION
# Description

Changes `children` type to be more accepted `ReactNode`(info: https://www.totaltypescript.com/jsx-element-vs-react-reactnode).  Fixes 

Fixes # 181 (issue) https://github.com/featurehub-io/featurehub-javascript-sdk/issues/181

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Not tested, could use a hand on how to build, etc.
