### PR TITLE
minor feature: for web 1.0 apps

### DIFF
--- a/.changeset/strict-snails-work.md
+++ b/.changeset/strict-snails-work.md
@@ -1,0 +1,6 @@
+---
+"featurehub-javascript-core-sdk": patch
+"featurehub-javascript-client-sdk": patch
+---
+
+Support for preventing polling on page change for Web 1.0 apps when the poll is not within the requisite interval

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+#### 2.0.3
+
+- If a web 1.0 is frequently page swapping, it will attempt to reload the
+features from FH on every page change, which is expensive and unnecessary.
+This change writes the timestamp of the last change (in ms) in the local storage,
+- and compares it with the frequency.
+
 #### 2.0.2
 
 - there was a spurious console.log in the polling code
@@ -10,8 +17,8 @@
   for javascript frameworks (e.g. React and Solid), particularly around support for
   testability and reloading, and also waiting for results to appear before rendering.
 - there was a bug in the code around Server Evaluated contexts swapping context details. When
-it happened, the repository would flip to "notReady" and never send a listener event again when
-it actually became ready.
+  it happened, the repository would flip to "notReady" and never send a listener event again when
+  it actually became ready.
 
 #### 2.0.1
 

--- a/packages/core/src/network/polling_sdk.ts
+++ b/packages/core/src/network/polling_sdk.ts
@@ -200,6 +200,9 @@ export class PollingBase implements PollingService {
       this.rejectOutstanding(e);
       throw e;
     } finally {
+      // if this has already been done, it is fine
+      clearTimeout(timeoutId);
+
       this._awaitingFirstPollResult = false;
     }
   }

--- a/packages/js/src/__tests__/polling_sdk.test.ts
+++ b/packages/js/src/__tests__/polling_sdk.test.ts
@@ -1,7 +1,9 @@
 import { Substitute, type SubstituteOf } from "@fluffy-spoon/substitute";
+import type { FeatureEnvironmentCollection } from "featurehub-javascript-core-sdk";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 import {
+  BrowserPollingService,
   type FeatureHubConfig,
   FeatureHubPollingClient,
   FHLog,
@@ -37,6 +39,8 @@ describe("basic polling sdk works as expected", () => {
     let dom: any;
     let originalWindow: any;
     let originalDocument: any;
+    let originalStorage: any;
+    let storage: any;
 
     beforeAll(async () => {
       // Create JSDOM environment to simulate browser
@@ -47,12 +51,19 @@ describe("basic polling sdk works as expected", () => {
         resources: "usable",
       });
 
+      storage = {};
+
       // Store original window
       originalWindow = (globalThis as any).window;
       originalDocument = (globalThis as any).document;
+      originalStorage = (globalThis as any).localStorage;
 
       // Set up browser-like environment
       (globalThis as any).window = dom.window;
+      (globalThis as any).localStorage = {
+        getItem: (key: string) => storage![key],
+        setItem: (key: string, val: any) => (storage![key] = val),
+      };
 
       Object.defineProperty(globalThis, "window", {
         value: dom.window,
@@ -75,6 +86,7 @@ describe("basic polling sdk works as expected", () => {
       // Restore original window
       (globalThis as any).window = originalWindow;
       (globalThis as any).document = originalDocument;
+      (globalThis as any).localStorage = originalStorage;
       dom.window.close();
     });
 
@@ -123,6 +135,28 @@ describe("basic polling sdk works as expected", () => {
 
       const sessionHash = await createBase64UrlSafeHash("sha256", "user-id:12345,session:abcdef");
       expect(sessionHash).toBe(SESSION_HASH);
+    });
+
+    it("should not actually attempt to poll if it is within the frequency window", async () => {
+      let features: Array<FeatureEnvironmentCollection> | undefined = undefined;
+      let src: string | undefined = undefined;
+
+      storage["http://localhost"] = JSON.stringify({ e: [], tz: Date.now() + 1000 });
+      const bp = new BrowserPollingService({}, "http://localhost", 3000, (e, s) => {
+        features = e;
+        src = s;
+      });
+
+      let result = await bp.preload(Substitute.for(), "http://localhost");
+      expect(result).to.be.true;
+      expect(src).to.eq("browser-store");
+      expect(features!.length).eq(0);
+
+      // when the timer exceeds the threshold, it should return false and let us poll
+
+      storage["http://localhost"] = JSON.stringify({ e: [], tz: Date.now() + 3001 });
+      result = await bp.preload(Substitute.for(), "http://localhost");
+      expect(result).to.be.false;
     });
   });
 });

--- a/packages/js/src/polling_sdk.ts
+++ b/packages/js/src/polling_sdk.ts
@@ -9,6 +9,11 @@ import { fhLog, PollingBase } from "featurehub-javascript-core-sdk";
 
 import { createBase64UrlSafeHash } from "./crypto-browser";
 
+interface StoredData {
+  e?: Array<FeatureEnvironmentCollection>;
+  tz?: number;
+}
+
 /**
  * This should never be used directly but we are exporting it because we need it
  */
@@ -39,10 +44,17 @@ export class BrowserPollingService extends PollingBase implements PollingService
       const storedData = BrowserPollingService.localStorageRequestor().getItem(url);
       if (storedData) {
         try {
-          const data = JSON.parse(storedData);
+          const data = JSON.parse(storedData) as StoredData;
           if (data.e) {
             // save space with short name
             this._callback(data.e as Array<FeatureEnvironmentCollection>, "browser-store");
+          }
+          // has the data been loaded from this host within the frequency period already? If so, lets not do it again and
+          // assume the poll has succeeded
+          if (data.e && data.tz) {
+            if (this._frequency !== 0 && Date.now() - data.tz < this._frequency) {
+              return true;
+            }
           }
         } catch (_) {
           // ignore exception
@@ -58,7 +70,7 @@ export class BrowserPollingService extends PollingBase implements PollingService
       if (this.localStorageLastUrl) {
         BrowserPollingService.localStorageRequestor().setItem(
           this.localStorageLastUrl,
-          JSON.stringify({ e: environments }),
+          JSON.stringify({ e: environments, tz: Date.now() }),
         );
       }
     } catch (_) {


### PR DESCRIPTION
# Description

If a web 1.0 is frequently page swapping, it will attempt to reload the features from FH on every page change, which is expensive and unnecessary. This change writes the timestamp of the last change (in ms) in the local storage,
- and compares it with the frequency.
